### PR TITLE
Fix Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-#Launchbar Menubar search
+# Launchbar Menubar search
+
 Launchbar action for quick access to the menubar. Based on the Alfred workflow
 from Ted Wise: [Menubar Search](http://www.alfredforum.com/topic/1993-menu-search).
 
-##Requirements
+## Requirements
+
 Support for assisted device must be enabled and allowed. On OSX El Capitan (10.11) and later
 this is done in the System preferences -> Security & Privacy -> Accessibility.
 
-##Screenshot
+## Screenshot
+
 ![Screenshot](screenshot.png "Screenshot")


### PR DESCRIPTION
Add spaces after the headline tags, now GitHub displays the headings correctly :-)